### PR TITLE
Include details in prediction response

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,7 +17,7 @@ To use these interactive docs:
 """
 
 app = FastAPI(
-    title='DS API',
+    title='DS API - Family Promise',
     description=description,
     docs_url='/',
 )


### PR DESCRIPTION
# PR Description
​
Prediction endpoint used to simply return a prediction string. Now it includes details about the prediction, explaining what features about the guest caused that prediction.
​
​
## Type of Change
​
- [] New feature
​
​
## Testing
​
- [] Yes
​
​
## Completeness
- [] Feature Complete
​
